### PR TITLE
stop creating directories ending with periods on Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 export function write(dir: string, filename: string, data: Buffer) {
   const file = path.join(dir, filename)
-  fs.mkdirpSync(file.slice(0, file.lastIndexOf('/')))
+  fs.mkdirpSync(path.dirname(file))
   return fs.writeFileSync(file, data)
 }
 


### PR DESCRIPTION
When using this package on Windows, it will create a directory ending with a period for every file saved to disk. This wreaks havoc with many Windows applications, as filenames ending with a period are not allowed on Windows when using the DOS-style paths, as most Windows applications do.

The problem stems from use of `String.lastIndexOf()` and `String.slice()` to separate the filename from the directory path. The prior call to `path.join()` will convert the slashes to the Windows style, so `String.lastIndexOf('/')` will never find the slash it is looking for. The solution is to utilize `path.dirname()` instead, as it is made for this purpose, and will handle details like this.